### PR TITLE
Typescript Parser should specify default ScriptKind.TS enum when parsing files

### DIFF
--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -53,7 +53,13 @@ export class TypescriptParser {
      * @memberof TsResourceParser
      */
     public async parseSource(source: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File> {
-        return await this.parseTypescript(createSourceFile('inline.tsx', source, ScriptTarget.ES2015, true, scriptKind), '/');
+        return await this.parseTypescript(
+          createSourceFile('inline.tsx',
+            source,
+            ScriptTarget.ES2015,
+            true,
+            scriptKind),
+          '/');
     }
 
     /**
@@ -81,7 +87,12 @@ export class TypescriptParser {
      */
     public async parseFiles(filePathes: string[], rootPath: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File[]> {
         return filePathes
-            .map(o => createSourceFile(o, readFileSync(o).toString(), ScriptTarget.ES2015, true, scriptKind))
+            .map(o => createSourceFile(o,
+              readFileSync(o).toString(),
+              ScriptTarget.ES2015,
+              true,
+              scriptKind)
+            )
             .map(o => this.parseTypescript(o, rootPath));
     }
 

--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -20,6 +20,7 @@ import {
     VariableStatement,
 } from 'typescript';
 
+import { parse } from 'path';
 import { parseClass } from './node-parser/class-parser';
 import { parseEnum } from './node-parser/enum-parser';
 import { parseExport } from './node-parser/export-parser';
@@ -48,6 +49,7 @@ export class TypescriptParser {
      * Mainly used to parse source code of a document.
      *
      * @param {string} source
+     * @param {ScriptKind} [scriptKind=ScriptKind.TS]
      * @returns {Promise<File>}
      *
      * @memberof TsResourceParser
@@ -91,9 +93,9 @@ export class TypescriptParser {
         rootPath: string): Promise<File[]> {
         return filePathes
             .map((o) => {
-                let scriptKind: ScriptKind = ScriptKind.TS;
-                const fileType: string = o.split('.').length ? <string>o.split('.').pop() : 'unknown';
-                switch (fileType.toLowerCase()) {
+                let scriptKind: ScriptKind = ScriptKind.Unknown;
+                const parsed = parse(o);
+                switch (parsed.ext.toLowerCase()) {
                     case 'js':
                         scriptKind = ScriptKind.JS;
                         break;
@@ -105,9 +107,6 @@ export class TypescriptParser {
                         break;
                     case 'tsx':
                         scriptKind = ScriptKind.TSX;
-                        break;
-                    case 'unknown':
-                        scriptKind = ScriptKind.Unknown;
                         break;
                 }
                 return createSourceFile(o,

--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -72,8 +72,8 @@ export class TypescriptParser {
      *
      * @memberof TsResourceParser
      */
-    public async parseFile(filePath: string, rootPath: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File> {
-        const parse = await this.parseFiles([filePath], rootPath, scriptKind);
+    public async parseFile(filePath: string, rootPath: string): Promise<File> {
+        const parse = await this.parseFiles([filePath], rootPath);
         return parse[0];
     }
 
@@ -88,10 +88,28 @@ export class TypescriptParser {
      */
     public async parseFiles(
         filePathes: string[],
-        rootPath: string,
-        scriptKind: ScriptKind = ScriptKind.TS): Promise<File[]> {
+        rootPath: string): Promise<File[]> {
         return filePathes
             .map((o) => {
+                let scriptKind: ScriptKind = ScriptKind.TS;
+                const fileType: string = o.split('.').length ? <string>o.split('.').pop() : 'unknown';
+                switch (fileType.toLowerCase()) {
+                    case 'js':
+                        scriptKind = ScriptKind.JS;
+                        break;
+                    case 'jsx':
+                        scriptKind = ScriptKind.JSX;
+                        break;
+                    case 'ts':
+                        scriptKind = ScriptKind.TS;
+                        break;
+                    case 'tsx':
+                        scriptKind = ScriptKind.TSX;
+                        break;
+                    case 'unknown':
+                        scriptKind = ScriptKind.Unknown;
+                        break;
+                }
                 return createSourceFile(o,
                                         readFileSync(o).toString(),
                                         ScriptTarget.ES2015,

--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -46,10 +46,10 @@ export class TypescriptParser {
     /**
      * Parses the given source into an anonymous File resource.
      * Mainly used to parse source code of a document.
-     * 
+     *
      * @param {string} source
      * @returns {Promise<File>}
-     * 
+     *
      * @memberof TsResourceParser
      */
     public async parseSource(source: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File> {
@@ -65,25 +65,25 @@ export class TypescriptParser {
 
     /**
      * Parses a single file into a parsed file.
-     * 
+     *
      * @param {string} filePath
      * @param {string} rootPath
      * @returns {Promise<File>}
-     * 
+     *
      * @memberof TsResourceParser
      */
-    public async parseFile(filePath: string, rootPath: string): Promise<File> {
-        const parse = await this.parseFiles([filePath], rootPath);
+    public async parseFile(filePath: string, rootPath: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File> {
+        const parse = await this.parseFiles([filePath], rootPath, scriptKind);
         return parse[0];
     }
 
     /**
      * Parses multiple files into parsed files.
-     * 
+     *
      * @param {string[]} filePathes
      * @param {string} rootPath
      * @returns {Promise<File[]>}
-     * 
+     *
      * @memberof TsResourceParser
      */
     public async parseFiles(
@@ -104,12 +104,12 @@ export class TypescriptParser {
     /**
      * Parses the typescript source into the file instance. Calls .parse afterwards to
      * get the declarations and other information about the source.
-     * 
+     *
      * @private
      * @param {SourceFile} source
      * @param {string} rootPath
      * @returns {TsFile}
-     * 
+     *
      * @memberof TsResourceParser
      */
     private parseTypescript(source: SourceFile, rootPath: string): File {
@@ -125,11 +125,11 @@ export class TypescriptParser {
      * Recursive function that runs through the AST of a source and parses the nodes.
      * Creates the class / function / etc declarations and instanciates a new module / namespace
      * resource if needed.
-     * 
+     *
      * @private
      * @param {Resource} resource
      * @param {Node} node
-     * 
+     *
      * @memberof TsResourceParser
      */
     private parse(resource: Resource, node: Node): void {

--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -46,29 +46,30 @@ export class TypescriptParser {
     /**
      * Parses the given source into an anonymous File resource.
      * Mainly used to parse source code of a document.
-     *
+     * 
      * @param {string} source
      * @returns {Promise<File>}
-     *
+     * 
      * @memberof TsResourceParser
      */
     public async parseSource(source: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File> {
         return await this.parseTypescript(
-          createSourceFile('inline.tsx',
-            source,
-            ScriptTarget.ES2015,
-            true,
-            scriptKind),
+          createSourceFile(
+              'inline.tsx',
+              source,
+              ScriptTarget.ES2015,
+              true,
+              scriptKind),
           '/');
     }
 
     /**
      * Parses a single file into a parsed file.
-     *
+     * 
      * @param {string} filePath
      * @param {string} rootPath
      * @returns {Promise<File>}
-     *
+     * 
      * @memberof TsResourceParser
      */
     public async parseFile(filePath: string, rootPath: string): Promise<File> {
@@ -78,33 +79,37 @@ export class TypescriptParser {
 
     /**
      * Parses multiple files into parsed files.
-     *
+     * 
      * @param {string[]} filePathes
      * @param {string} rootPath
      * @returns {Promise<File[]>}
-     *
+     * 
      * @memberof TsResourceParser
      */
-    public async parseFiles(filePathes: string[], rootPath: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File[]> {
+    public async parseFiles(
+        filePathes: string[],
+        rootPath: string,
+        scriptKind: ScriptKind = ScriptKind.TS): Promise<File[]> {
         return filePathes
-            .map(o => createSourceFile(o,
-              readFileSync(o).toString(),
-              ScriptTarget.ES2015,
-              true,
-              scriptKind)
-            )
+            .map((o) => {
+                return createSourceFile(o,
+                                        readFileSync(o).toString(),
+                                        ScriptTarget.ES2015,
+                                        true,
+                                        scriptKind);
+            })
             .map(o => this.parseTypescript(o, rootPath));
     }
 
     /**
      * Parses the typescript source into the file instance. Calls .parse afterwards to
      * get the declarations and other information about the source.
-     *
+     * 
      * @private
      * @param {SourceFile} source
      * @param {string} rootPath
      * @returns {TsFile}
-     *
+     * 
      * @memberof TsResourceParser
      */
     private parseTypescript(source: SourceFile, rootPath: string): File {
@@ -120,11 +125,11 @@ export class TypescriptParser {
      * Recursive function that runs through the AST of a source and parses the nodes.
      * Creates the class / function / etc declarations and instanciates a new module / namespace
      * resource if needed.
-     *
+     * 
      * @private
      * @param {Resource} resource
      * @param {Node} node
-     *
+     * 
      * @memberof TsResourceParser
      */
     private parse(resource: Resource, node: Node): void {

--- a/src/TypescriptParser.ts
+++ b/src/TypescriptParser.ts
@@ -12,6 +12,7 @@ import {
     InterfaceDeclaration,
     ModuleDeclaration,
     Node,
+    ScriptKind,
     ScriptTarget,
     SourceFile,
     SyntaxKind,
@@ -37,7 +38,7 @@ import { Resource } from './resources/Resource';
  * This class is the parser of the whole extension. It uses the typescript compiler to parse a file or given
  * source code into the token stream and therefore into the AST of the source. Afterwards an array of
  * resources is generated and returned.
- * 
+ *
  * @export
  * @class TypescriptParser
  */
@@ -45,23 +46,23 @@ export class TypescriptParser {
     /**
      * Parses the given source into an anonymous File resource.
      * Mainly used to parse source code of a document.
-     * 
+     *
      * @param {string} source
      * @returns {Promise<File>}
-     * 
+     *
      * @memberof TsResourceParser
      */
-    public async parseSource(source: string): Promise<File> {
-        return await this.parseTypescript(createSourceFile('inline.tsx', source, ScriptTarget.ES2015, true), '/');
+    public async parseSource(source: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File> {
+        return await this.parseTypescript(createSourceFile('inline.tsx', source, ScriptTarget.ES2015, true, scriptKind), '/');
     }
 
     /**
      * Parses a single file into a parsed file.
-     * 
+     *
      * @param {string} filePath
      * @param {string} rootPath
      * @returns {Promise<File>}
-     * 
+     *
      * @memberof TsResourceParser
      */
     public async parseFile(filePath: string, rootPath: string): Promise<File> {
@@ -71,28 +72,28 @@ export class TypescriptParser {
 
     /**
      * Parses multiple files into parsed files.
-     * 
+     *
      * @param {string[]} filePathes
      * @param {string} rootPath
      * @returns {Promise<File[]>}
-     * 
+     *
      * @memberof TsResourceParser
      */
-    public async parseFiles(filePathes: string[], rootPath: string): Promise<File[]> {
+    public async parseFiles(filePathes: string[], rootPath: string, scriptKind: ScriptKind = ScriptKind.TS): Promise<File[]> {
         return filePathes
-            .map(o => createSourceFile(o, readFileSync(o).toString(), ScriptTarget.ES2015, true))
+            .map(o => createSourceFile(o, readFileSync(o).toString(), ScriptTarget.ES2015, true, scriptKind))
             .map(o => this.parseTypescript(o, rootPath));
     }
 
     /**
      * Parses the typescript source into the file instance. Calls .parse afterwards to
      * get the declarations and other information about the source.
-     * 
+     *
      * @private
      * @param {SourceFile} source
      * @param {string} rootPath
      * @returns {TsFile}
-     * 
+     *
      * @memberof TsResourceParser
      */
     private parseTypescript(source: SourceFile, rootPath: string): File {
@@ -108,11 +109,11 @@ export class TypescriptParser {
      * Recursive function that runs through the AST of a source and parses the nodes.
      * Creates the class / function / etc declarations and instanciates a new module / namespace
      * resource if needed.
-     * 
+     *
      * @private
      * @param {Resource} resource
      * @param {Node} node
-     * 
+     *
      * @memberof TsResourceParser
      */
     private parse(resource: Resource, node: Node): void {

--- a/test/TypescriptParser.spec.ts
+++ b/test/TypescriptParser.spec.ts
@@ -21,6 +21,7 @@ import { Namespace } from '../src/resources/Namespace';
 import { Resource } from '../src/resources/Resource';
 import { TypescriptParser } from '../src/TypescriptParser';
 import { getWorkspaceFile, rootPath } from './testUtilities';
+import { ScriptKind } from 'typescript';
 
 describe('TypescriptParser', () => {
 
@@ -439,7 +440,7 @@ describe('TypescriptParser', () => {
             let parsed: Resource;
 
             beforeEach(async () => {
-                parsed = await parser.parseFile(file, rootPath);
+                parsed = await parser.parseFile(file, rootPath, ScriptKind.TS);
             });
 
             it('should parse a file', () => {
@@ -466,7 +467,7 @@ describe('TypescriptParser', () => {
         let parsed: Resource;
 
         beforeEach(async () => {
-            parsed = await parser.parseFile(file, rootPath);
+            parsed = await parser.parseFile(file, rootPath, ScriptKind.TS);
         });
 
         it('should parse decorator usages', () => {
@@ -579,7 +580,7 @@ describe('TypescriptParser', () => {
         let parsed: Resource;
 
         beforeEach(async () => {
-            parsed = await parser.parseFile(file, rootPath);
+            parsed = await parser.parseFile(file, rootPath, ScriptKind.TSX);
         });
 
         it('should parse a tsx element usage', () => {
@@ -617,7 +618,7 @@ describe('TypescriptParser', () => {
         });
 
         it('should parseSource correctly', async () => {
-            const parsedSource = await parser.parseSource(readFileSync(file).toString());
+            const parsedSource = await parser.parseSource(readFileSync(file).toString(), ScriptKind.TSX);
 
             expect(parsedSource.usages).toMatchSnapshot();
         });
@@ -656,7 +657,7 @@ describe('TypescriptParser', () => {
 
             it('should parse the correct usages with "parseFile"', async () => {
                 const file = getWorkspaceFile(`typescript-parser/specific-cases/${testFile.filename}`);
-                const parsed = await parser.parseFile(file, rootPath);
+                const parsed = await parser.parseFile(file, rootPath, ScriptKind.TSX);
 
                 for (const usage of testFile.requiredUsages) {
                     expect(parsed.usages).toContain(usage);
@@ -667,7 +668,7 @@ describe('TypescriptParser', () => {
 
             it('should parse the correct usages with "parseFiles"', async () => {
                 const file = getWorkspaceFile(`typescript-parser/specific-cases/${testFile.filename}`);
-                const parsed = (await parser.parseFiles([file], rootPath))[0];
+                const parsed = (await parser.parseFiles([file], rootPath, ScriptKind.TSX))[0];
 
                 for (const usage of testFile.requiredUsages) {
                     expect(parsed.usages).toContain(usage);
@@ -679,7 +680,7 @@ describe('TypescriptParser', () => {
             it('should parse the correct usages with "parseSource"', async () => {
                 const file = getWorkspaceFile(`typescript-parser/specific-cases/${testFile.filename}`);
                 const fileSource = readFileSync(file).toString();
-                const parsed = await parser.parseSource(fileSource);
+                const parsed = await parser.parseSource(fileSource, ScriptKind.TSX);
 
                 for (const usage of testFile.requiredUsages) {
                     expect(parsed.usages).toContain(usage);
@@ -697,7 +698,7 @@ describe('TypescriptParser', () => {
         const file = getWorkspaceFile('typescript-parser/javascript.js');
 
         it('should parse a simple javascript file correctly with "parseFile"', async () => {
-            const parsed = await parser.parseFile(file, rootPath);
+            const parsed = await parser.parseFile(file, rootPath, ScriptKind.JS);
             delete parsed.filePath;
             delete (parsed as any).rootPath;
 
@@ -705,7 +706,7 @@ describe('TypescriptParser', () => {
         });
 
         it('should parse a simple javascript file correctly with "parseFiles"', async () => {
-            const parsed = await parser.parseFiles([file], rootPath);
+            const parsed = await parser.parseFiles([file], rootPath, ScriptKind.JS);
             delete parsed[0].filePath;
             delete (parsed[0] as any).rootPath;
 
@@ -714,7 +715,7 @@ describe('TypescriptParser', () => {
 
         it('should parse a simple javascript file correctly with "parseSource"', async () => {
             const content = readFileSync(file).toString();
-            const parsed = await parser.parseSource(content);
+            const parsed = await parser.parseSource(content, ScriptKind.JS);
 
             expect(parsed).toMatchSnapshot();
         });
@@ -726,7 +727,7 @@ describe('TypescriptParser', () => {
         const file = getWorkspaceFile('typescript-parser/jsx.jsx');
 
         it('should parse a simple javascript react file correctly with "parseFile"', async () => {
-            const parsed = await parser.parseFile(file, rootPath);
+            const parsed = await parser.parseFile(file, rootPath, ScriptKind.JSX);
             delete parsed.filePath;
             delete (parsed as any).rootPath;
 
@@ -734,7 +735,7 @@ describe('TypescriptParser', () => {
         });
 
         it('should parse a simple javascript react file correctly with "parseFiles"', async () => {
-            const parsed = await parser.parseFiles([file], rootPath);
+            const parsed = await parser.parseFiles([file], rootPath, ScriptKind.JSX);
             delete parsed[0].filePath;
             delete (parsed[0] as any).rootPath;
 
@@ -743,7 +744,7 @@ describe('TypescriptParser', () => {
 
         it('should parse a simple javascript react file correctly with "parseSource"', async () => {
             const content = readFileSync(file).toString();
-            const parsed = await parser.parseSource(content);
+            const parsed = await parser.parseSource(content, ScriptKind.JSX);
 
             expect(parsed).toMatchSnapshot();
         });
@@ -757,7 +758,7 @@ describe('TypescriptParser', () => {
                 public test() {
                     let a = <T>() => { let b = null; };
                 }
-            }`);
+            }`, ScriptKind.TS);
             expect(parsed).toMatchSnapshot();
         });
 

--- a/test/TypescriptParser.spec.ts
+++ b/test/TypescriptParser.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { ScriptKind } from 'typescript';
 
 import { ClassDeclaration } from '../src/declarations/ClassDeclaration';
 import { DeclarationVisibility } from '../src/declarations/DeclarationVisibility';
@@ -21,7 +22,6 @@ import { Namespace } from '../src/resources/Namespace';
 import { Resource } from '../src/resources/Resource';
 import { TypescriptParser } from '../src/TypescriptParser';
 import { getWorkspaceFile, rootPath } from './testUtilities';
-import { ScriptKind } from 'typescript';
 
 describe('TypescriptParser', () => {
 

--- a/test/TypescriptParser.spec.ts
+++ b/test/TypescriptParser.spec.ts
@@ -440,7 +440,7 @@ describe('TypescriptParser', () => {
             let parsed: Resource;
 
             beforeEach(async () => {
-                parsed = await parser.parseFile(file, rootPath, ScriptKind.TS);
+                parsed = await parser.parseFile(file, rootPath);
             });
 
             it('should parse a file', () => {
@@ -467,7 +467,7 @@ describe('TypescriptParser', () => {
         let parsed: Resource;
 
         beforeEach(async () => {
-            parsed = await parser.parseFile(file, rootPath, ScriptKind.TS);
+            parsed = await parser.parseFile(file, rootPath);
         });
 
         it('should parse decorator usages', () => {
@@ -580,7 +580,7 @@ describe('TypescriptParser', () => {
         let parsed: Resource;
 
         beforeEach(async () => {
-            parsed = await parser.parseFile(file, rootPath, ScriptKind.TSX);
+            parsed = await parser.parseFile(file, rootPath);
         });
 
         it('should parse a tsx element usage', () => {
@@ -657,7 +657,7 @@ describe('TypescriptParser', () => {
 
             it('should parse the correct usages with "parseFile"', async () => {
                 const file = getWorkspaceFile(`typescript-parser/specific-cases/${testFile.filename}`);
-                const parsed = await parser.parseFile(file, rootPath, ScriptKind.TSX);
+                const parsed = await parser.parseFile(file, rootPath);
 
                 for (const usage of testFile.requiredUsages) {
                     expect(parsed.usages).toContain(usage);
@@ -668,7 +668,7 @@ describe('TypescriptParser', () => {
 
             it('should parse the correct usages with "parseFiles"', async () => {
                 const file = getWorkspaceFile(`typescript-parser/specific-cases/${testFile.filename}`);
-                const parsed = (await parser.parseFiles([file], rootPath, ScriptKind.TSX))[0];
+                const parsed = (await parser.parseFiles([file], rootPath))[0];
 
                 for (const usage of testFile.requiredUsages) {
                     expect(parsed.usages).toContain(usage);
@@ -698,7 +698,7 @@ describe('TypescriptParser', () => {
         const file = getWorkspaceFile('typescript-parser/javascript.js');
 
         it('should parse a simple javascript file correctly with "parseFile"', async () => {
-            const parsed = await parser.parseFile(file, rootPath, ScriptKind.JS);
+            const parsed = await parser.parseFile(file, rootPath);
             delete parsed.filePath;
             delete (parsed as any).rootPath;
 
@@ -706,7 +706,7 @@ describe('TypescriptParser', () => {
         });
 
         it('should parse a simple javascript file correctly with "parseFiles"', async () => {
-            const parsed = await parser.parseFiles([file], rootPath, ScriptKind.JS);
+            const parsed = await parser.parseFiles([file], rootPath);
             delete parsed[0].filePath;
             delete (parsed[0] as any).rootPath;
 
@@ -727,7 +727,7 @@ describe('TypescriptParser', () => {
         const file = getWorkspaceFile('typescript-parser/jsx.jsx');
 
         it('should parse a simple javascript react file correctly with "parseFile"', async () => {
-            const parsed = await parser.parseFile(file, rootPath, ScriptKind.JSX);
+            const parsed = await parser.parseFile(file, rootPath);
             delete parsed.filePath;
             delete (parsed as any).rootPath;
 
@@ -735,7 +735,7 @@ describe('TypescriptParser', () => {
         });
 
         it('should parse a simple javascript react file correctly with "parseFiles"', async () => {
-            const parsed = await parser.parseFiles([file], rootPath, ScriptKind.JSX);
+            const parsed = await parser.parseFiles([file], rootPath);
             delete parsed[0].filePath;
             delete (parsed[0] as any).rootPath;
 

--- a/test/__snapshots__/TypescriptParser.spec.ts.snap
+++ b/test/__snapshots__/TypescriptParser.spec.ts.snap
@@ -1492,7 +1492,7 @@ File {
       "isExported": true,
       "methods": Array [
         MethodDeclaration {
-          "end": 144,
+          "end": 130,
           "isAbstract": false,
           "name": "test",
           "parameters": Array [],
@@ -1500,11 +1500,19 @@ File {
           "type": undefined,
           "variables": Array [
             VariableDeclaration {
-              "end": 144,
+              "end": 112,
               "isConst": false,
               "isExported": false,
               "name": "a",
               "start": 77,
+              "type": undefined,
+            },
+            VariableDeclaration {
+              "end": 109,
+              "isConst": false,
+              "isExported": false,
+              "name": "b",
+              "start": 96,
               "type": undefined,
             },
           ],
@@ -1526,9 +1534,7 @@ File {
   "usages": Array [
     "a",
     "T",
-    "let",
-    undefined,
-    "",
+    "b",
   ],
 }
 `;


### PR DESCRIPTION
Typescript Parser should specify default ScriptKind.TS enum when parsing files.