### PR TITLE
Feature/windows support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,21 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "8"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/src/DeclarationIndex.ts
+++ b/src/DeclarationIndex.ts
@@ -12,7 +12,7 @@ import { Namespace } from './resources/Namespace';
 import { Resource } from './resources/Resource';
 import { isExportableDeclaration } from './type-guards/TypescriptHeroGuards';
 import { TypescriptParser } from './TypescriptParser';
-import { normalizeFilename, normalizePathUri } from './utilities/PathHelpers';
+import { normalizeFilename, normalizePathUri, toPosix } from './utilities/PathHelpers';
 
 /**
  * Returns the name of the node folder. Is used as the library name for indexing.
@@ -308,7 +308,7 @@ export class DeclarationIndex {
                 break;
             }
             if (ex instanceof AllExport || ex instanceof NamedExport) {
-                const exported = '/' + relative(this.rootPath, normalize(join(resource.parsedPath.dir, ex.from)));
+                const exported = '/' + toPosix(relative(this.rootPath, normalize(join(resource.parsedPath.dir, ex.from))));
                 exportsResource = exported === resourcePath;
             }
         }

--- a/src/utilities/PathHelpers.ts
+++ b/src/utilities/PathHelpers.ts
@@ -25,5 +25,16 @@ export function normalizePathUri(uri: string): string {
  * @returns {string} 
  */
 export function normalizeFilename(filepath: string): string {
-    return filepath.replace(/([.]d)?[.](t|j)sx?$/g, '');
+    return toPosix(filepath.replace(/([.]d)?[.](t|j)sx?$/g, ''));
+}
+
+/**
+ * On Windows, replaces all backslash delimeters with forward slashes.
+ * On other OSes, returns the path unmodified.
+ */
+export function toPosix(path: string): string {
+    if (platform() === 'win32') {
+        return path.replace(/\\/g, '/');
+    }
+    return path;
 }

--- a/test/declaration-index/DeclarationIndex.spec.ts
+++ b/test/declaration-index/DeclarationIndex.spec.ts
@@ -1,5 +1,5 @@
 import mockFs = require('mock-fs');
-import { join, resolve } from 'path';
+import { join, resolve } from '../testUtilities';
 
 import { DeclarationIndex } from '../../src/DeclarationIndex';
 import { ClassDeclaration } from '../../src/declarations';

--- a/test/declaration-index/specific-cases/body-parser/DeclarationIndex.body-parser.spec.ts
+++ b/test/declaration-index/specific-cases/body-parser/DeclarationIndex.body-parser.spec.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, resolve } from '../../../testUtilities';
 
 import { DeclarationIndex } from '../../../../src/DeclarationIndex';
 import { TypescriptParser } from '../../../../src/TypescriptParser';

--- a/test/declaration-index/specific-cases/reindex-with-global-module/DeclarationIndex.reindex-with-global-module-export.spec.ts
+++ b/test/declaration-index/specific-cases/reindex-with-global-module/DeclarationIndex.reindex-with-global-module-export.spec.ts
@@ -1,5 +1,5 @@
 import { FileChanges } from '../../../../src';
-import { join, resolve } from 'path';
+import { join, resolve } from '../../../testUtilities';
 
 import { DeclarationIndex } from '../../../../src/DeclarationIndex';
 import { TypescriptParser } from '../../../../src/TypescriptParser';

--- a/test/testUtilities.ts
+++ b/test/testUtilities.ts
@@ -1,7 +1,18 @@
-import { resolve } from 'path';
+import * as Path from 'path';
+import { toPosix } from '../src/utilities/PathHelpers';
 
 export function getWorkspaceFile(pathFromWorkspace: string): string {
     return resolve(__dirname, '_workspace', pathFromWorkspace);
+}
+
+// Like path.resolve, but always replaces backslashes with forward slashes on Windows.
+export function resolve(...paths: string[]): string {
+    return toPosix(Path.resolve(...paths));
+}
+
+// Like path.join, but always replaces backslashes with forward slashes on Windows.
+export function join(...paths: string[]): string {
+    return toPosix(Path.join(...paths));
 }
 
 export const rootPath = resolve(__dirname, '_workspace');


### PR DESCRIPTION
Adds support for running on Windows.  Some path-related operations were assuming a posix OS.  Now paths are always normalized to Posix-style forward-slash delimiters.  Windows will accept both slashes as a delimiter and does not allow forward slashes in file or directory names, so this should be safe and predictable to users.