### PR TITLE
Fix #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "tslib": "^1.7.1",
-    "typescript": "2.4.2"
+    "typescript": "^2.5.3"
   }
 }

--- a/src/DeclarationIndex.ts
+++ b/src/DeclarationIndex.ts
@@ -118,7 +118,7 @@ export class DeclarationIndex {
      */
     public get declarationInfos(): DeclarationInfo[] {
         return Object
-            .keys(this.index)
+            .keys(this.index!)
             .sort()
             .reduce((all, key) => all.concat(this.index![key]), <DeclarationInfo[]>[]);
     }

--- a/test/TypescriptParser.spec.ts
+++ b/test/TypescriptParser.spec.ts
@@ -51,7 +51,7 @@ describe('TypescriptParser', () => {
         });
 
         it('should parse imports', () => {
-            expect(parsed.imports).toHaveLength(9);
+            expect(parsed.imports).toHaveLength(12);
             expect(parsed.imports).toMatchSnapshot();
         });
 

--- a/test/__snapshots__/TypescriptParser.spec.ts.snap
+++ b/test/__snapshots__/TypescriptParser.spec.ts.snap
@@ -1012,6 +1012,36 @@ Array [
     ],
     "start": 400,
   },
+  NamedImport {
+    "defaultAlias": "__DefaultAlias",
+    "end": 540,
+    "libraryName": "namedImport",
+    "specifiers": Array [
+      SymbolSpecifier {
+        "alias": "__Specifier1",
+        "specifier": "Specifier1",
+      },
+    ],
+    "start": 456,
+  },
+  NamedImport {
+    "defaultAlias": "__DefaultAlias",
+    "end": 614,
+    "libraryName": "namedImport",
+    "specifiers": Array [
+      SymbolSpecifier {
+        "alias": "__Specifier1",
+        "specifier": "Specifier1",
+      },
+    ],
+    "start": 541,
+  },
+  NamespaceImport {
+    "alias": "__namespaceImport",
+    "end": 662,
+    "libraryName": "namespace",
+    "start": 615,
+  },
 ]
 `;
 

--- a/test/_workspace/typescript-parser/importsOnly.ts
+++ b/test/_workspace/typescript-parser/importsOnly.ts
@@ -10,3 +10,6 @@ import {
 import Foobar from 'aFile';
 import { default as DefaultAlias, Specifier1 } from 'namedImport';
 import DefaultAlias, { Specifier1 } from 'namedImport';
+import { default as __DefaultAlias, Specifier1 as __Specifier1 } from 'namedImport';
+import __DefaultAlias, { Specifier1 as __Specifier1 } from 'namedImport';
+import * as __namespaceImport from 'namespace';


### PR DESCRIPTION
Upgrading to TypeScript 2.5 fixes the issue where identifiers starting with two underscores would have a third added.  All other tests still pass.

Fixes #35 and buehler/typescript-hero#320.