### PR TITLE
Optional configuration for `multiple imports per line` and strictly `one import per line`.

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -7,7 +7,7 @@
         "outDir": "../build",
         "rootDir": "../src",
         "declaration": true,
-        "sourceMap": false,
+        "sourceMap": true,
         "importHelpers": true,
         "strictNullChecks": true,
         "experimentalDecorators": true,

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -7,7 +7,7 @@
         "outDir": "../build",
         "rootDir": "../src",
         "declaration": true,
-        "sourceMap": true,
+        "sourceMap": false,
         "importHelpers": true,
         "strictNullChecks": true,
         "experimentalDecorators": true,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/TypeScript-Heroes/node-typescript-parser#readme",
   "devDependencies": {
+    "@types/lodash-es": "^4.17.0",
     "@types/jest": "^21.1.8",
     "@types/mock-fs": "^3.6.30",
     "@types/node": "^8.0.57",
@@ -45,7 +46,8 @@
     "typedoc": "^0.9.0"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.5",
+    "lodash-es": "^4.17.5",
     "tslib": "^1.8.1",
     "typescript": "^2.6.2"
   }

--- a/src/code-generators/TypescriptGenerationOptions.ts
+++ b/src/code-generators/TypescriptGenerationOptions.ts
@@ -30,6 +30,14 @@ export interface TypescriptGenerationOptions {
     spaceBraces: boolean;
 
     /**
+     * The wrapping method to be used in multiline imports.
+     *
+     * @type {'MULTIPLE_IMPORTS_PER_LINE' | 'ONE_IMPORT_PER_LINE'}
+     * @memberof TypescriptGenerationOptions
+     */
+    multiLineWrapMethod: 'ONE_IMPORT_PER_LINE' | 'MULTIPLE_IMPORTS_PER_LINE';
+
+    /**
      * The threshold where an import is written as multiline.
      *
      * @type {number}

--- a/src/code-generators/TypescriptGenerationOptions.ts
+++ b/src/code-generators/TypescriptGenerationOptions.ts
@@ -1,3 +1,9 @@
+export enum MultiLineImportRule {
+    strictlyOneImportPerLine = 'strictlyOneImportPerLine',
+    oneImportPerLineOnlyAfterThreshold = 'oneImportPerLineOnlyAfterThreshold',
+    multipleImportsPerLine = 'multipleImportsPerLine',
+}
+
 /**
  * Typescript generation options type. Contains all information needed to stringify some objects to typescript.
  *
@@ -30,12 +36,12 @@ export interface TypescriptGenerationOptions {
     spaceBraces: boolean;
 
     /**
-     * The wrapping method to be used in multiline imports.
+     * The wrapping methodology to be used for imports.
      *
-     * @type {'MULTIPLE_IMPORTS_PER_LINE' | 'ONE_IMPORT_PER_LINE'}
+     * @type {MultiLineImportRule}
      * @memberof TypescriptGenerationOptions
      */
-    multiLineWrapMethod: 'ONE_IMPORT_PER_LINE' | 'MULTIPLE_IMPORTS_PER_LINE';
+    wrapMethod: MultiLineImportRule;
 
     /**
      * The threshold where an import is written as multiline.
@@ -60,4 +66,12 @@ export interface TypescriptGenerationOptions {
      * @memberof TypescriptGenerationOptions
      */
     tabSize: number;
+
+    /**
+     * Insert spaces instead of tabs (default: true)
+     *
+     * @type {boolean}
+     * @memberof TypescriptGenerationOptions
+     */
+    insertSpaces: boolean;
 }

--- a/src/code-generators/typescript-generators/namedImport.ts
+++ b/src/code-generators/typescript-generators/namedImport.ts
@@ -57,6 +57,7 @@ export function generateNamedImport(
     const lib = `${stringQuoteStyle}${imp.libraryName}${stringQuoteStyle}${eol}`;
 
     const specifiers = imp.specifiers.sort(specifierSort).map(o => generateSymbolSpecifier(o)).join(', ');
+    let retVal:string = '';
 
     if (specifiers.length > multiLineWrapThreshold) {
         const spacings = Array(tabSize + 1).join(' ');
@@ -64,41 +65,46 @@ export function generateNamedImport(
         let importSpecifierStrings: string = '';
 
         if (multiLineWrapMethod === 'MULTIPLE_IMPORTS_PER_LINE') {
-          importSpecifierStrings = sortedImportSpecifiers.reduce((acc, curr) => {
-            const symbolSpecifier: string = generateSymbolSpecifier(curr);
-            const dist: number = acc.out.length - acc.lastWrapOffset + symbolSpecifier.length;
-            const needsWrap: boolean = dist >= multiLineWrapThreshold;
-            return {
-                out: acc.out + (needsWrap ? `,\n${spacings}` : (acc.out.length ? `, ` : `${spacings}`)) + symbolSpecifier,
-                lastWrapOffset: acc.lastWrapOffset + (needsWrap ? dist : 0)
-            };
-        }, {
-            out: '',
-            lastWrapOffset: 0,
-        }).out
+            importSpecifierStrings = sortedImportSpecifiers.reduce(
+                (acc, curr) => {
+                    const symbolSpecifier: string = generateSymbolSpecifier(curr);
+                    const dist: number = acc.out.length - acc.lastWrapOffset + symbolSpecifier.length;
+                    const needsWrap: boolean = dist >= multiLineWrapThreshold;
+                    return {
+                        out: acc.out + (needsWrap ? `,\n${spacings}` : (acc.out.length ? `, ` : `${spacings}`)) +
+                        symbolSpecifier,
+                        lastWrapOffset: acc.lastWrapOffset + (needsWrap ? dist : 0),
+                    };
+                },
+                {
+                    out: '',
+                    lastWrapOffset: 0,
+                },
+            ).out;
         } else {
-          // For 'ONE_IMPORT_PER_LINE' which also happens to be the default case.
-          importSpecifierStrings = sortedImportSpecifiers.map(o => `${spacings}${generateSymbolSpecifier(o)}`).join(',\n');
+            // For 'ONE_IMPORT_PER_LINE' which also happens to be the default case.
+            importSpecifierStrings = sortedImportSpecifiers.map(o => `${spacings}${generateSymbolSpecifier(o)}`).join(',\n');
         }
         if (imp.specifiers.length > 0) {
-          return multiLineImport(
-            importSpecifierStrings,
-            multiLineTrailingComma ? ',' : '',
-            `${stringQuoteStyle}${imp.libraryName}${stringQuoteStyle}${eol}`,
-            imp.defaultAlias ? `${imp.defaultAlias}, ` : '',
-          );
+            retVal = multiLineImport(
+                importSpecifierStrings,
+                multiLineTrailingComma ? ',' : '',
+                `${stringQuoteStyle}${imp.libraryName}${stringQuoteStyle}${eol}`,
+                imp.defaultAlias ? `${imp.defaultAlias}, ` : '',
+            );
         } else {
-          return aliasOnlyMultiLineImport(
-            imp.defaultAlias ? `${imp.defaultAlias}, ` : '',
-            `${stringQuoteStyle}${imp.libraryName}${stringQuoteStyle}${eol}`,
-          );
+            retVal = aliasOnlyMultiLineImport(
+                imp.defaultAlias ? `${imp.defaultAlias}, ` : '',
+                `${stringQuoteStyle}${imp.libraryName}${stringQuoteStyle}${eol}`,
+            );
         }
     } else {
-      return importTemplate(
-          getImportSpecifiers(imp, spaceBraces),
-          lib,
-      );
+        retVal = importTemplate(
+            getImportSpecifiers(imp, spaceBraces),
+            lib,
+        );
     }
+    return retVal;
 }
 
 function getImportSpecifiers(namedImport: NamedImport, spaceBraces: boolean): string {

--- a/test/code-generators/TypescriptCodeGenerator.spec.ts
+++ b/test/code-generators/TypescriptCodeGenerator.spec.ts
@@ -37,6 +37,9 @@ multiLineNamedImport.specifiers = [
     new SymbolSpecifier('spec13'),
     new SymbolSpecifier('spec14'),
     new SymbolSpecifier('spec15'),
+    new SymbolSpecifier('spec16'),
+    new SymbolSpecifier('spec17'),
+    new SymbolSpecifier('spec18'),
 ];
 
 const defaultImport = new NamedImport('defaultImport');
@@ -54,6 +57,7 @@ describe('TypescriptCodeGenerator', () => {
     const defaultOptions: TypescriptGenerationOptions = {
         eol: ';',
         multiLineTrailingComma: true,
+        multiLineWrapMethod: 'ONE_IMPORT_PER_LINE',
         multiLineWrapThreshold: 125,
         spaceBraces: true,
         stringQuoteStyle: `'`,
@@ -62,6 +66,16 @@ describe('TypescriptCodeGenerator', () => {
     const impOptions: TypescriptGenerationOptions = {
         eol: ';',
         multiLineTrailingComma: true,
+        multiLineWrapMethod: 'ONE_IMPORT_PER_LINE',
+        multiLineWrapThreshold: 125,
+        spaceBraces: true,
+        stringQuoteStyle: `"`,
+        tabSize: 2,
+    };
+    const impOptions_multipleImportsPerLine: TypescriptGenerationOptions = {
+        eol: ';',
+        multiLineTrailingComma: true,
+        multiLineWrapMethod: 'MULTIPLE_IMPORTS_PER_LINE',
         multiLineWrapThreshold: 125,
         spaceBraces: true,
         stringQuoteStyle: `"`,
@@ -135,6 +149,18 @@ describe('TypescriptCodeGenerator', () => {
 
         it(`should generate the correct code for ${imp.constructor.name} with double quote`, () => {
             const generator = new TypescriptCodeGenerator(impOptions);
+
+            expect(generator.generate(imp)).toMatchSnapshot();
+        });
+
+        it(`should generate multiple imports per line for ${imp.constructor.name} with single quote`, () => {
+            const generator = new TypescriptCodeGenerator(impOptions_multipleImportsPerLine);
+
+            expect(generator.generate(imp)).toMatchSnapshot();
+        });
+
+        it(`should generate multiple imports per line for ${imp.constructor.name} with double quote`, () => {
+            const generator = new TypescriptCodeGenerator(impOptions_multipleImportsPerLine);
 
             expect(generator.generate(imp)).toMatchSnapshot();
         });

--- a/test/code-generators/TypescriptCodeGenerator.spec.ts
+++ b/test/code-generators/TypescriptCodeGenerator.spec.ts
@@ -1,5 +1,5 @@
 import { TypescriptCodeGenerator } from '../../src/code-generators/TypescriptCodeGenerator';
-import { TypescriptGenerationOptions } from '../../src/code-generators/TypescriptGenerationOptions';
+import { TypescriptGenerationOptions, MultiLineImportRule } from '../../src/code-generators/TypescriptGenerationOptions';
 import { ClassDeclaration } from '../../src/declarations';
 import { GetterDeclaration, SetterDeclaration } from '../../src/declarations/AccessorDeclaration';
 import { DeclarationVisibility } from '../../src/declarations/DeclarationVisibility';
@@ -57,29 +57,42 @@ describe('TypescriptCodeGenerator', () => {
     const defaultOptions: TypescriptGenerationOptions = {
         eol: ';',
         multiLineTrailingComma: true,
-        multiLineWrapMethod: 'ONE_IMPORT_PER_LINE',
+        wrapMethod: MultiLineImportRule.oneImportPerLineOnlyAfterThreshold,
         multiLineWrapThreshold: 125,
         spaceBraces: true,
         stringQuoteStyle: `'`,
         tabSize: 4,
+        insertSpaces: true,
     };
-    const impOptions: TypescriptGenerationOptions = {
+    const impOptions_oneImportPerLineOnlyAfterThreshold: TypescriptGenerationOptions = {
         eol: ';',
         multiLineTrailingComma: true,
-        multiLineWrapMethod: 'ONE_IMPORT_PER_LINE',
+        wrapMethod: MultiLineImportRule.oneImportPerLineOnlyAfterThreshold,
         multiLineWrapThreshold: 125,
         spaceBraces: true,
         stringQuoteStyle: `"`,
         tabSize: 2,
+        insertSpaces: true,
+    };
+    const impOptions_strictlyOneImportPerLine: TypescriptGenerationOptions = {
+        eol: ';',
+        multiLineTrailingComma: true,
+        wrapMethod: MultiLineImportRule.strictlyOneImportPerLine,
+        multiLineWrapThreshold: 125,
+        spaceBraces: true,
+        stringQuoteStyle: `"`,
+        tabSize: 2,
+        insertSpaces: true,
     };
     const impOptions_multipleImportsPerLine: TypescriptGenerationOptions = {
         eol: ';',
         multiLineTrailingComma: true,
-        multiLineWrapMethod: 'MULTIPLE_IMPORTS_PER_LINE',
+        wrapMethod: MultiLineImportRule.multipleImportsPerLine,
         multiLineWrapThreshold: 125,
         spaceBraces: true,
         stringQuoteStyle: `"`,
         tabSize: 2,
+        insertSpaces: true,
     };
     const imports = [
         new ExternalModuleImport('externalModuleLib', 'externalAlias'),
@@ -148,7 +161,19 @@ describe('TypescriptCodeGenerator', () => {
         });
 
         it(`should generate the correct code for ${imp.constructor.name} with double quote`, () => {
-            const generator = new TypescriptCodeGenerator(impOptions);
+            const generator = new TypescriptCodeGenerator(defaultOptions);
+
+            expect(generator.generate(imp)).toMatchSnapshot();
+        });
+
+        it(`should generate the correct code for ${imp.constructor.name} with double quote`, () => {
+            const generator = new TypescriptCodeGenerator(impOptions_oneImportPerLineOnlyAfterThreshold);
+
+            expect(generator.generate(imp)).toMatchSnapshot();
+        });
+
+        it(`should generate the correct code for ${imp.constructor.name} with double quote`, () => {
+            const generator = new TypescriptCodeGenerator(impOptions_strictlyOneImportPerLine);
 
             expect(generator.generate(imp)).toMatchSnapshot();
         });
@@ -158,13 +183,6 @@ describe('TypescriptCodeGenerator', () => {
 
             expect(generator.generate(imp)).toMatchSnapshot();
         });
-
-        it(`should generate multiple imports per line for ${imp.constructor.name} with double quote`, () => {
-            const generator = new TypescriptCodeGenerator(impOptions_multipleImportsPerLine);
-
-            expect(generator.generate(imp)).toMatchSnapshot();
-        });
-
     }
 
     it('should throw on non generatable element', () => {

--- a/test/code-generators/__snapshots__/TypescriptCodeGenerator.spec.ts.snap
+++ b/test/code-generators/__snapshots__/TypescriptCodeGenerator.spec.ts.snap
@@ -1,34 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TypescriptCodeGenerator should generate multiple imports per line for ExternalModuleImport with double quote 1`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
-
 exports[`TypescriptCodeGenerator should generate multiple imports per line for ExternalModuleImport with single quote 1`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 1`] = `"import { spec1, spec2 as alias2 } from \\"namedLib\\";"`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 2`] = `
-"import {
-,
-} from \\"multiLineNamedLib\\";"
-`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 3`] = `"import { } from \\"emptyImport\\";"`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 4`] = `"import Default from \\"defaultImport\\";"`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 5`] = `"import Default, { spec1, spec2 as alias2 } from \\"defaultWithNamedImport\\";"`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 6`] = `
-"import Default, {
-,
-} from \\"defaultWithNamedMultilineImport\\";"
-`;
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 1`] = `"import { spec1, spec2 as alias2 } from \\"namedLib\\";"`;
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 2`] = `
 "import {
-,
+  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
+  spec8, spec9,
 } from \\"multiLineNamedLib\\";"
 `;
 
@@ -40,21 +19,22 @@ exports[`TypescriptCodeGenerator should generate multiple imports per line for N
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 6`] = `
 "import Default, {
-,
+  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
+  spec8, spec9,
 } from \\"defaultWithNamedMultilineImport\\";"
 `;
 
-exports[`TypescriptCodeGenerator should generate multiple imports per line for NamespaceImport with double quote 1`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
-
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamespaceImport with single quote 1`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
-
-exports[`TypescriptCodeGenerator should generate multiple imports per line for StringImport with double quote 1`] = `"import \\"stringLib\\";"`;
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for StringImport with single quote 1`] = `"import \\"stringLib\\";"`;
 
 exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport 1`] = `"import externalAlias = require('externalModuleLib');"`;
 
-exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport with double quote 1`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
+exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport with double quote 1`] = `"import externalAlias = require('externalModuleLib');"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport with double quote 2`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport with double quote 3`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
 
 exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport with single quote 1`] = `"import externalAlias = require('externalModuleLib');"`;
 
@@ -152,7 +132,24 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport 2`] = `
 "import {
-,
+    spec1,
+    spec10,
+    spec11,
+    spec12,
+    spec13,
+    spec14,
+    spec15,
+    spec16,
+    spec17,
+    spec18,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    spec6,
+    spec7,
+    spec8,
+    spec9,
 } from 'multiLineNamedLib';"
 `;
 
@@ -164,27 +161,196 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport 6`] = `
 "import Default, {
-,
+    spec1,
+    spec10,
+    spec11,
+    spec12,
+    spec13,
+    spec14,
+    spec15,
+    spec16,
+    spec17,
+    spec18,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    spec6,
+    spec7,
+    spec8,
+    spec9,
 } from 'defaultWithNamedMultilineImport';"
 `;
 
-exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 1`] = `"import { spec1, spec2 as alias2 } from \\"namedLib\\";"`;
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 1`] = `"import { spec1, spec2 as alias2 } from 'namedLib';"`;
 
-exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 2`] = `
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 2`] = `"import { spec1, spec2 as alias2 } from \\"namedLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 3`] = `
 "import {
-,
+  spec1,
+  spec2 as alias2,
+} from \\"namedLib\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 4`] = `
+"import {
+    spec1,
+    spec10,
+    spec11,
+    spec12,
+    spec13,
+    spec14,
+    spec15,
+    spec16,
+    spec17,
+    spec18,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    spec6,
+    spec7,
+    spec8,
+    spec9,
+} from 'multiLineNamedLib';"
+`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 5`] = `
+"import {
+  spec1,
+  spec10,
+  spec11,
+  spec12,
+  spec13,
+  spec14,
+  spec15,
+  spec16,
+  spec17,
+  spec18,
+  spec2,
+  spec3,
+  spec4,
+  spec5,
+  spec6,
+  spec7,
+  spec8,
+  spec9,
 } from \\"multiLineNamedLib\\";"
 `;
 
-exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 3`] = `"import { } from \\"emptyImport\\";"`;
-
-exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 4`] = `"import Default from \\"defaultImport\\";"`;
-
-exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 5`] = `"import Default, { spec1, spec2 as alias2 } from \\"defaultWithNamedImport\\";"`;
-
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 6`] = `
+"import {
+  spec1,
+  spec10,
+  spec11,
+  spec12,
+  spec13,
+  spec14,
+  spec15,
+  spec16,
+  spec17,
+  spec18,
+  spec2,
+  spec3,
+  spec4,
+  spec5,
+  spec6,
+  spec7,
+  spec8,
+  spec9,
+} from \\"multiLineNamedLib\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 7`] = `"import { } from 'emptyImport';"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 8`] = `"import { } from \\"emptyImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 9`] = `"import { } from \\"emptyImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 10`] = `"import Default from 'defaultImport';"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 11`] = `"import Default from \\"defaultImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 12`] = `"import Default from \\"defaultImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 13`] = `"import Default, { spec1, spec2 as alias2 } from 'defaultWithNamedImport';"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 14`] = `"import Default, { spec1, spec2 as alias2 } from \\"defaultWithNamedImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 15`] = `
 "import Default, {
-,
+  spec1,
+  spec2 as alias2,
+} from \\"defaultWithNamedImport\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 16`] = `
+"import Default, {
+    spec1,
+    spec10,
+    spec11,
+    spec12,
+    spec13,
+    spec14,
+    spec15,
+    spec16,
+    spec17,
+    spec18,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    spec6,
+    spec7,
+    spec8,
+    spec9,
+} from 'defaultWithNamedMultilineImport';"
+`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 17`] = `
+"import Default, {
+  spec1,
+  spec10,
+  spec11,
+  spec12,
+  spec13,
+  spec14,
+  spec15,
+  spec16,
+  spec17,
+  spec18,
+  spec2,
+  spec3,
+  spec4,
+  spec5,
+  spec6,
+  spec7,
+  spec8,
+  spec9,
+} from \\"defaultWithNamedMultilineImport\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 18`] = `
+"import Default, {
+  spec1,
+  spec10,
+  spec11,
+  spec12,
+  spec13,
+  spec14,
+  spec15,
+  spec16,
+  spec17,
+  spec18,
+  spec2,
+  spec3,
+  spec4,
+  spec5,
+  spec6,
+  spec7,
+  spec8,
+  spec9,
 } from \\"defaultWithNamedMultilineImport\\";"
 `;
 
@@ -192,7 +358,24 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with single quote 2`] = `
 "import {
-,
+    spec1,
+    spec10,
+    spec11,
+    spec12,
+    spec13,
+    spec14,
+    spec15,
+    spec16,
+    spec17,
+    spec18,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    spec6,
+    spec7,
+    spec8,
+    spec9,
 } from 'multiLineNamedLib';"
 `;
 
@@ -204,13 +387,34 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with single quote 6`] = `
 "import Default, {
-,
+    spec1,
+    spec10,
+    spec11,
+    spec12,
+    spec13,
+    spec14,
+    spec15,
+    spec16,
+    spec17,
+    spec18,
+    spec2,
+    spec3,
+    spec4,
+    spec5,
+    spec6,
+    spec7,
+    spec8,
+    spec9,
 } from 'defaultWithNamedMultilineImport';"
 `;
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamespaceImport 1`] = `"import * as namespaceAlias from 'namespaceLib';"`;
 
-exports[`TypescriptCodeGenerator should generate the correct code for NamespaceImport with double quote 1`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
+exports[`TypescriptCodeGenerator should generate the correct code for NamespaceImport with double quote 1`] = `"import * as namespaceAlias from 'namespaceLib';"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamespaceImport with double quote 2`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for NamespaceImport with double quote 3`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamespaceImport with single quote 1`] = `"import * as namespaceAlias from 'namespaceLib';"`;
 
@@ -283,7 +487,11 @@ exports[`TypescriptCodeGenerator should generate the correct code for SetterDecl
 
 exports[`TypescriptCodeGenerator should generate the correct code for StringImport 1`] = `"import 'stringLib';"`;
 
-exports[`TypescriptCodeGenerator should generate the correct code for StringImport with double quote 1`] = `"import \\"stringLib\\";"`;
+exports[`TypescriptCodeGenerator should generate the correct code for StringImport with double quote 1`] = `"import 'stringLib';"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for StringImport with double quote 2`] = `"import \\"stringLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate the correct code for StringImport with double quote 3`] = `"import \\"stringLib\\";"`;
 
 exports[`TypescriptCodeGenerator should generate the correct code for StringImport with single quote 1`] = `"import 'stringLib';"`;
 

--- a/test/code-generators/__snapshots__/TypescriptCodeGenerator.spec.ts.snap
+++ b/test/code-generators/__snapshots__/TypescriptCodeGenerator.spec.ts.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TypescriptCodeGenerator should generate multiple imports per line for ExternalModuleImport with double quote 1`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for ExternalModuleImport with single quote 1`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 1`] = `"import { spec1, spec2 as alias2 } from \\"namedLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 2`] = `
+"import {
+  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
+  spec8, spec9,
+} from \\"multiLineNamedLib\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 3`] = `"import { } from \\"emptyImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 4`] = `"import Default from \\"defaultImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 5`] = `"import Default, { spec1, spec2 as alias2 } from \\"defaultWithNamedImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 6`] = `
+"import Default, {
+  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
+  spec8, spec9,
+} from \\"defaultWithNamedMultilineImport\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 1`] = `"import { spec1, spec2 as alias2 } from \\"namedLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 2`] = `
+"import {
+  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
+  spec8, spec9,
+} from \\"multiLineNamedLib\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 3`] = `"import { } from \\"emptyImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 4`] = `"import Default from \\"defaultImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 5`] = `"import Default, { spec1, spec2 as alias2 } from \\"defaultWithNamedImport\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 6`] = `
+"import Default, {
+  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
+  spec8, spec9,
+} from \\"defaultWithNamedMultilineImport\\";"
+`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamespaceImport with double quote 1`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for NamespaceImport with single quote 1`] = `"import * as namespaceAlias from \\"namespaceLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for StringImport with double quote 1`] = `"import \\"stringLib\\";"`;
+
+exports[`TypescriptCodeGenerator should generate multiple imports per line for StringImport with single quote 1`] = `"import \\"stringLib\\";"`;
+
 exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport 1`] = `"import externalAlias = require('externalModuleLib');"`;
 
 exports[`TypescriptCodeGenerator should generate the correct code for ExternalModuleImport with double quote 1`] = `"import externalAlias = require(\\"externalModuleLib\\");"`;
@@ -107,6 +163,9 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
     spec13,
     spec14,
     spec15,
+    spec16,
+    spec17,
+    spec18,
     spec2,
     spec3,
     spec4,
@@ -133,6 +192,9 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
     spec13,
     spec14,
     spec15,
+    spec16,
+    spec17,
+    spec18,
     spec2,
     spec3,
     spec4,
@@ -155,6 +217,9 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
   spec13,
   spec14,
   spec15,
+  spec16,
+  spec17,
+  spec18,
   spec2,
   spec3,
   spec4,
@@ -181,6 +246,9 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
   spec13,
   spec14,
   spec15,
+  spec16,
+  spec17,
+  spec18,
   spec2,
   spec3,
   spec4,
@@ -203,6 +271,9 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
     spec13,
     spec14,
     spec15,
+    spec16,
+    spec17,
+    spec18,
     spec2,
     spec3,
     spec4,
@@ -229,6 +300,9 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
     spec13,
     spec14,
     spec15,
+    spec16,
+    spec17,
+    spec18,
     spec2,
     spec3,
     spec4,

--- a/test/code-generators/__snapshots__/TypescriptCodeGenerator.spec.ts.snap
+++ b/test/code-generators/__snapshots__/TypescriptCodeGenerator.spec.ts.snap
@@ -8,8 +8,7 @@ exports[`TypescriptCodeGenerator should generate multiple imports per line for N
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 2`] = `
 "import {
-  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
-  spec8, spec9,
+,
 } from \\"multiLineNamedLib\\";"
 `;
 
@@ -21,8 +20,7 @@ exports[`TypescriptCodeGenerator should generate multiple imports per line for N
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with double quote 6`] = `
 "import Default, {
-  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
-  spec8, spec9,
+,
 } from \\"defaultWithNamedMultilineImport\\";"
 `;
 
@@ -30,8 +28,7 @@ exports[`TypescriptCodeGenerator should generate multiple imports per line for N
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 2`] = `
 "import {
-  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
-  spec8, spec9,
+,
 } from \\"multiLineNamedLib\\";"
 `;
 
@@ -43,8 +40,7 @@ exports[`TypescriptCodeGenerator should generate multiple imports per line for N
 
 exports[`TypescriptCodeGenerator should generate multiple imports per line for NamedImport with single quote 6`] = `
 "import Default, {
-  spec1, spec10, spec11, spec12, spec13, spec14, spec15, spec16, spec17, spec18, spec2, spec3, spec4, spec5, spec6, spec7,
-  spec8, spec9,
+,
 } from \\"defaultWithNamedMultilineImport\\";"
 `;
 
@@ -156,24 +152,7 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport 2`] = `
 "import {
-    spec1,
-    spec10,
-    spec11,
-    spec12,
-    spec13,
-    spec14,
-    spec15,
-    spec16,
-    spec17,
-    spec18,
-    spec2,
-    spec3,
-    spec4,
-    spec5,
-    spec6,
-    spec7,
-    spec8,
-    spec9,
+,
 } from 'multiLineNamedLib';"
 `;
 
@@ -185,24 +164,7 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport 6`] = `
 "import Default, {
-    spec1,
-    spec10,
-    spec11,
-    spec12,
-    spec13,
-    spec14,
-    spec15,
-    spec16,
-    spec17,
-    spec18,
-    spec2,
-    spec3,
-    spec4,
-    spec5,
-    spec6,
-    spec7,
-    spec8,
-    spec9,
+,
 } from 'defaultWithNamedMultilineImport';"
 `;
 
@@ -210,24 +172,7 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 2`] = `
 "import {
-  spec1,
-  spec10,
-  spec11,
-  spec12,
-  spec13,
-  spec14,
-  spec15,
-  spec16,
-  spec17,
-  spec18,
-  spec2,
-  spec3,
-  spec4,
-  spec5,
-  spec6,
-  spec7,
-  spec8,
-  spec9,
+,
 } from \\"multiLineNamedLib\\";"
 `;
 
@@ -239,24 +184,7 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with double quote 6`] = `
 "import Default, {
-  spec1,
-  spec10,
-  spec11,
-  spec12,
-  spec13,
-  spec14,
-  spec15,
-  spec16,
-  spec17,
-  spec18,
-  spec2,
-  spec3,
-  spec4,
-  spec5,
-  spec6,
-  spec7,
-  spec8,
-  spec9,
+,
 } from \\"defaultWithNamedMultilineImport\\";"
 `;
 
@@ -264,24 +192,7 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with single quote 2`] = `
 "import {
-    spec1,
-    spec10,
-    spec11,
-    spec12,
-    spec13,
-    spec14,
-    spec15,
-    spec16,
-    spec17,
-    spec18,
-    spec2,
-    spec3,
-    spec4,
-    spec5,
-    spec6,
-    spec7,
-    spec8,
-    spec9,
+,
 } from 'multiLineNamedLib';"
 `;
 
@@ -293,24 +204,7 @@ exports[`TypescriptCodeGenerator should generate the correct code for NamedImpor
 
 exports[`TypescriptCodeGenerator should generate the correct code for NamedImport with single quote 6`] = `
 "import Default, {
-    spec1,
-    spec10,
-    spec11,
-    spec12,
-    spec13,
-    spec14,
-    spec15,
-    spec16,
-    spec17,
-    spec18,
-    spec2,
-    spec3,
-    spec4,
-    spec5,
-    spec6,
-    spec7,
-    spec8,
-    spec9,
+,
 } from 'defaultWithNamedMultilineImport';"
 `;
 


### PR DESCRIPTION
As per buehler/typescript-hero/issues/379, there should be an option
`multiLineWrapMethod`, where a user can choose between:
`ONE_IMPORT_PER_LINE`
OR
`MULTIPLE_IMPORTS_PER_LINE`