### PR TITLE
Better JS/TS typing with initializers 

### DIFF
--- a/src/node-parser/class-parser.ts
+++ b/src/node-parser/class-parser.ts
@@ -201,7 +201,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                     (o.name as Identifier).text,
                     o.modifiers !== undefined && o.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword),
                     getNodeVisibility(o),
-                    getNodeType(o.type),
+                    getNodeType(o),
                     !!o.questionToken,
                     containsModifier(o, SyntaxKind.StaticKeyword),
                     containsModifier(o, SyntaxKind.AsyncKeyword),

--- a/src/node-parser/class-parser.ts
+++ b/src/node-parser/class-parser.ts
@@ -78,7 +78,7 @@ export function parseCtorParams(
         if (isIdentifier(o.name)) {
             ctor.parameters.push(
                 new TshParameter(
-                    (o.name as Identifier).text, getNodeType(o.type), o.getStart(), o.getEnd(),
+                    (o.name as Identifier).text, getNodeType(o), o.getStart(), o.getEnd(),
                 ),
             );
             if (!o.modifiers) {
@@ -88,7 +88,7 @@ export function parseCtorParams(
                 new TshProperty(
                     (o.name as Identifier).text,
                     getNodeVisibility(o),
-                    getNodeType(o.type),
+                    getNodeType(o),
                     !!o.questionToken,
                     containsModifier(o, SyntaxKind.StaticKeyword),
                     o.getStart(),
@@ -139,7 +139,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                         new TshProperty(
                             (o.name as Identifier).text,
                             getNodeVisibility(o),
-                            getNodeType(o.type),
+                            getNodeType(o),
                             !!o.questionToken,
                             containsModifier(o, SyntaxKind.StaticKeyword),
                             o.getStart(),
@@ -152,7 +152,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                         new TshProperty(
                             (o.name as Identifier).text,
                             getNodeVisibility(o),
-                            getNodeType(o.type),
+                            getNodeType(o),
                             !!o.questionToken,
                             containsModifier(o, SyntaxKind.StaticKeyword),
                             o.getStart(),
@@ -168,7 +168,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                     new GetterDeclaration(
                         (o.name as Identifier).text,
                         getNodeVisibility(o),
-                        getNodeType(o.type),
+                        getNodeType(o),
                         o.modifiers !== undefined && o.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword),
                         containsModifier(o, SyntaxKind.StaticKeyword),
                         o.getStart(),
@@ -182,7 +182,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                     new SetterDeclaration(
                         (o.name as Identifier).text,
                         getNodeVisibility(o),
-                        getNodeType(o.type),
+                        getNodeType(o),
                         o.modifiers !== undefined && o.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword),
                         containsModifier(o, SyntaxKind.StaticKeyword),
                         o.getStart(),

--- a/src/node-parser/class-parser.ts
+++ b/src/node-parser/class-parser.ts
@@ -78,7 +78,7 @@ export function parseCtorParams(
         if (isIdentifier(o.name)) {
             ctor.parameters.push(
                 new TshParameter(
-                    (o.name as Identifier).text, getNodeType(o), o.getStart(), o.getEnd(),
+                    (o.name as Identifier).text, getNodeType(o.type, o), o.getStart(), o.getEnd(),
                 ),
             );
             if (!o.modifiers) {
@@ -88,7 +88,7 @@ export function parseCtorParams(
                 new TshProperty(
                     (o.name as Identifier).text,
                     getNodeVisibility(o),
-                    getNodeType(o),
+                    getNodeType(o.type, o),
                     !!o.questionToken,
                     containsModifier(o, SyntaxKind.StaticKeyword),
                     o.getStart(),
@@ -139,7 +139,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                         new TshProperty(
                             (o.name as Identifier).text,
                             getNodeVisibility(o),
-                            getNodeType(o),
+                            getNodeType(o.type, o),
                             !!o.questionToken,
                             containsModifier(o, SyntaxKind.StaticKeyword),
                             o.getStart(),
@@ -152,7 +152,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                         new TshProperty(
                             (o.name as Identifier).text,
                             getNodeVisibility(o),
-                            getNodeType(o),
+                            getNodeType(o.type, o),
                             !!o.questionToken,
                             containsModifier(o, SyntaxKind.StaticKeyword),
                             o.getStart(),
@@ -168,7 +168,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                     new GetterDeclaration(
                         (o.name as Identifier).text,
                         getNodeVisibility(o),
-                        getNodeType(o),
+                        getNodeType(o.type, o),
                         o.modifiers !== undefined && o.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword),
                         containsModifier(o, SyntaxKind.StaticKeyword),
                         o.getStart(),
@@ -182,7 +182,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                     new SetterDeclaration(
                         (o.name as Identifier).text,
                         getNodeVisibility(o),
-                        getNodeType(o),
+                        getNodeType(o.type, o),
                         o.modifiers !== undefined && o.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword),
                         containsModifier(o, SyntaxKind.StaticKeyword),
                         o.getStart(),
@@ -201,7 +201,7 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                     (o.name as Identifier).text,
                     o.modifiers !== undefined && o.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword),
                     getNodeVisibility(o),
-                    getNodeType(o),
+                    getNodeType(o.type, o),
                     !!o.questionToken,
                     containsModifier(o, SyntaxKind.StaticKeyword),
                     containsModifier(o, SyntaxKind.AsyncKeyword),

--- a/src/node-parser/function-parser.ts
+++ b/src/node-parser/function-parser.ts
@@ -11,6 +11,7 @@ import {
     PropertySignature,
     SyntaxKind,
     VariableStatement,
+    TypeNode,
 } from 'typescript';
 
 import { ConstructorDeclaration as TshConstructor } from '../declarations/ConstructorDeclaration';
@@ -83,7 +84,7 @@ export function parseMethodParams(
             const params = all;
             if (isIdentifier(cur.name)) {
                 params.push(new TshParameter(
-                    (cur.name as Identifier).text, getNodeType(cur.type), cur.getStart(), cur.getEnd(),
+                    (cur.name as Identifier).text, getNodeType(cur), cur.getStart(), cur.getEnd(),
                 ));
             } else if (isObjectBindingPattern(cur.name)) {
                 const elements = cur.name.elements;
@@ -95,7 +96,7 @@ export function parseMethodParams(
                 } else if (cur.type && isTypeLiteralNode(cur.type)) {
                     types = cur.type.members
                         .filter(member => isPropertySignature(member))
-                        .map((signature: any) => getNodeType((signature as PropertySignature).type));
+                        .map((signature: any) => getNodeType((signature as PropertySignature)));
                 }
 
                 boundParam.parameters = elements.map((bindingElement, index) => new TshParameter(
@@ -112,9 +113,9 @@ export function parseMethodParams(
                 const boundParam = new ArrayBoundParameterDeclaration(cur.getStart(), cur.getEnd());
 
                 if (cur.type && isTypeReferenceNode(cur.type)) {
-                    boundParam.typeReference = getNodeType(cur.type);
+                    boundParam.typeReference = getNodeType(cur);
                 } else if (cur.type && isTupleTypeNode(cur.type)) {
-                    types = cur.type.elementTypes.map(type => getNodeType(type));
+                    types = cur.type.elementTypes.map((type:TypeNode) => { return type ? type.getText() :undefined});
                 }
 
                 boundParam.parameters = elements.map((bindingElement, index) => new TshParameter(
@@ -146,7 +147,7 @@ export function parseFunction(resource: Resource, node: FunctionDeclaration): vo
         name,
         isNodeExported(node),
         containsModifier(node, SyntaxKind.AsyncKeyword),
-        getNodeType(node.type),
+        getNodeType(node),
         node.getStart(),
         node.getEnd(),
     );

--- a/src/node-parser/function-parser.ts
+++ b/src/node-parser/function-parser.ts
@@ -10,8 +10,8 @@ import {
     ParameterDeclaration,
     PropertySignature,
     SyntaxKind,
-    VariableStatement,
     TypeNode,
+    VariableStatement,
 } from 'typescript';
 
 import { ConstructorDeclaration as TshConstructor } from '../declarations/ConstructorDeclaration';
@@ -115,7 +115,7 @@ export function parseMethodParams(
                 if (cur.type && isTypeReferenceNode(cur.type)) {
                     boundParam.typeReference = getNodeType(cur);
                 } else if (cur.type && isTupleTypeNode(cur.type)) {
-                    types = cur.type.elementTypes.map((type:TypeNode) => { return type ? type.getText() :undefined});
+                    types = cur.type.elementTypes.map((type:TypeNode) => { return type ? type.getText() :undefined; });
                 }
 
                 boundParam.parameters = elements.map((bindingElement, index) => new TshParameter(

--- a/src/node-parser/function-parser.ts
+++ b/src/node-parser/function-parser.ts
@@ -84,7 +84,7 @@ export function parseMethodParams(
             const params = all;
             if (isIdentifier(cur.name)) {
                 params.push(new TshParameter(
-                    (cur.name as Identifier).text, getNodeType(cur), cur.getStart(), cur.getEnd(),
+                    (cur.name as Identifier).text, getNodeType(cur.type, cur), cur.getStart(), cur.getEnd(),
                 ));
             } else if (isObjectBindingPattern(cur.name)) {
                 const elements = cur.name.elements;
@@ -92,11 +92,13 @@ export function parseMethodParams(
                 const boundParam = new ObjectBoundParameterDeclaration(cur.getStart(), cur.getEnd());
 
                 if (cur.type && isTypeReferenceNode(cur.type)) {
-                    boundParam.typeReference = getNodeType(cur);
+                    boundParam.typeReference = getNodeType(cur.type, cur);
                 } else if (cur.type && isTypeLiteralNode(cur.type)) {
                     types = cur.type.members
                         .filter(member => isPropertySignature(member))
-                        .map((signature: any) => getNodeType((signature as PropertySignature)));
+                        .map((signature: any) => getNodeType(
+                        (signature as PropertySignature).type,
+                        (signature as PropertySignature)));
                 }
 
                 boundParam.parameters = elements.map((bindingElement, index) => new TshParameter(
@@ -113,7 +115,7 @@ export function parseMethodParams(
                 const boundParam = new ArrayBoundParameterDeclaration(cur.getStart(), cur.getEnd());
 
                 if (cur.type && isTypeReferenceNode(cur.type)) {
-                    boundParam.typeReference = getNodeType(cur);
+                    boundParam.typeReference = getNodeType(cur.type, cur);
                 } else if (cur.type && isTupleTypeNode(cur.type)) {
                     types = cur.type.elementTypes.map((type:TypeNode) => { return type ? type.getText() :undefined; });
                 }
@@ -147,7 +149,7 @@ export function parseFunction(resource: Resource, node: FunctionDeclaration): vo
         name,
         isNodeExported(node),
         containsModifier(node, SyntaxKind.AsyncKeyword),
-        getNodeType(node),
+        getNodeType(node.type, node),
         node.getStart(),
         node.getEnd(),
     );

--- a/src/node-parser/function-parser.ts
+++ b/src/node-parser/function-parser.ts
@@ -92,7 +92,7 @@ export function parseMethodParams(
                 const boundParam = new ObjectBoundParameterDeclaration(cur.getStart(), cur.getEnd());
 
                 if (cur.type && isTypeReferenceNode(cur.type)) {
-                    boundParam.typeReference = getNodeType(cur.type);
+                    boundParam.typeReference = getNodeType(cur);
                 } else if (cur.type && isTypeLiteralNode(cur.type)) {
                     types = cur.type.members
                         .filter(member => isPropertySignature(member))

--- a/src/node-parser/interface-parser.ts
+++ b/src/node-parser/interface-parser.ts
@@ -42,7 +42,7 @@ export function parseInterface(resource: Resource, node: InterfaceDeclaration): 
                     new PropertyDeclaration(
                         (o.name as Identifier).text,
                         DeclarationVisibility.Public,
-                        getNodeType(o),
+                        getNodeType(o.type, o),
                         !!o.questionToken,
                         containsModifier(o, SyntaxKind.StaticKeyword),
                         o.getStart(),
@@ -54,7 +54,7 @@ export function parseInterface(resource: Resource, node: InterfaceDeclaration): 
                     (o.name as Identifier).text,
                     true,
                     DeclarationVisibility.Public,
-                    getNodeType(o),
+                    getNodeType(o.type, o),
                     !!o.questionToken,
                     containsModifier(o, SyntaxKind.StaticKeyword),
                     containsModifier(o, SyntaxKind.AsyncKeyword),

--- a/src/node-parser/interface-parser.ts
+++ b/src/node-parser/interface-parser.ts
@@ -42,7 +42,7 @@ export function parseInterface(resource: Resource, node: InterfaceDeclaration): 
                     new PropertyDeclaration(
                         (o.name as Identifier).text,
                         DeclarationVisibility.Public,
-                        getNodeType(o.type),
+                        getNodeType(o),
                         !!o.questionToken,
                         containsModifier(o, SyntaxKind.StaticKeyword),
                         o.getStart(),
@@ -54,7 +54,7 @@ export function parseInterface(resource: Resource, node: InterfaceDeclaration): 
                     (o.name as Identifier).text,
                     true,
                     DeclarationVisibility.Public,
-                    getNodeType(o.type),
+                    getNodeType(o),
                     !!o.questionToken,
                     containsModifier(o, SyntaxKind.StaticKeyword),
                     containsModifier(o, SyntaxKind.AsyncKeyword),

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -1,4 +1,14 @@
-import { Declaration, getCombinedModifierFlags, ModifierFlags, Node, SyntaxKind, isStringLiteral, isNumericLiteral, isArrayLiteralExpression, isObjectLiteralExpression } from 'typescript';
+import { 
+    Declaration,
+    getCombinedModifierFlags,
+    isArrayLiteralExpression,
+    isNumericLiteral,
+    isObjectLiteralExpression,
+    isStringLiteral, 
+    ModifierFlags,
+    Node,
+    SyntaxKind,
+} from 'typescript';
 
 import { DeclarationVisibility } from '../declarations/DeclarationVisibility';
 import { File } from '../resources/File';
@@ -38,58 +48,56 @@ export function isNodeDefaultExported(node: Node): boolean {
  * @returns {(string | undefined)}
  */
 export function getNodeType(node:any): string | undefined {
-    if( node == undefined ){
+    if( node == undefined ) {
         return node;
     }
-    else if(node.type){
+    else if(node.type) {
         return node.type.getText();
     }
     else if(node.initializer){
-        let initializer = node.initializer;
-        if(initializer != undefined){
-            if(["true","false"].indexOf(initializer.getText()) != -1){
-                return "boolean"
+        const initializer = node.initializer;
+        if(initializer !== undefined) {
+            if(['true','false'].indexOf(initializer.getText()) !== -1){
+                return 'boolean';
             }
             return getNodeType(initializer);
         }
         
     }
-    else if(isStringLiteral(node)){
-        return "string"
+    else if(isStringLiteral(node)) {
+        return 'string';
     }
-    else if(isNumericLiteral(node)){
-        return "number";
+    else if(isNumericLiteral(node)) {
+        return 'number';
     }
-    else if(isArrayLiteralExpression(node)){
-        var type:Array<string> = [];
-        for(var i = 0;node.elements.length>i;i++){
-           var curType:string | undefined = getNodeType(node.elements[i]);
-           if(type.length == 0 && curType != undefined ){
+    else if(isArrayLiteralExpression(node)) {
+        const type:Array<string> = [];
+        for(let i = 0;node.elements.length>i;i++) {
+           let curType:string | undefined = getNodeType(node.elements[i]);
+           if(type.length == 0 && curType !== undefined ) {
                 type.push(curType);
            }
-           else if(curType != undefined && type.indexOf(curType) == -1){
+           else if(curType !== undefined && type.indexOf(curType) === -1) {
                type.push(curType);
            }
         }
-        if(type.length ==1){
-            return 'Array<'+type[0]+'>'
+        if(type.length ===1) {
+            return 'Array<' + type[0] + '>';
         }
-        else {
-            return 'Array<any>'
-        }
+        return 'Array<any>';
     }
-    else if(isObjectLiteralExpression(node)){
-        var count = 0;
-        let output = "{ ";
-        for(let prop of node.properties){
-            let identif = prop.getText();
-            output+= identif.slice(0,identif.indexOf(":")+1)+" "+getNodeType(prop);
-            if(count != node.properties.length-1){
-                output+=", "
+    else if(isObjectLiteralExpression(node)) {
+        let count = 0;
+        let output = '{ ';
+        for(const prop of node.properties) {
+            const identif = prop.getText();
+            output+= identif.slice(0,identif.indexOf(':') + 1) + ' '+ getNodeType(prop);
+            if(count !== node.properties.length-1) {
+                output+= ', ';
             }
             count+=1;
         }
-        output+=" }"
+        output+= ' }';
         return output;
     }
 }

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -10,9 +10,19 @@ import {
     SyntaxKind,
 } from 'typescript';
 
+import {
+    FunctionDeclaration,
+    GetterDeclaration,
+    MethodDeclaration,
+    ParameterDeclaration,
+    PropertyDeclaration,
+    SetterDeclaration,
+} from '../declarations';
+
 import { DeclarationVisibility } from '../declarations/DeclarationVisibility';
 import { File } from '../resources/File';
 import { Resource } from '../resources/Resource';
+import { isPropertySignature } from '../type-guards/TypescriptGuards';
 
 /**
  * Checks if the given typescript node has the exported flag.
@@ -50,8 +60,16 @@ export function isNodeDefaultExported(node: Node): boolean {
 export function getNodeType(node:any): string | undefined {
     if (node === undefined) {
         return node;
-    } else if (node.type) {
-        return node.type.getText();
+    } else if (node instanceof FunctionDeclaration
+        || node instanceof PropertyDeclaration
+        || node instanceof GetterDeclaration
+        || node instanceof SetterDeclaration
+        || node instanceof MethodDeclaration
+        || node instanceof ParameterDeclaration) {
+        return node.type ? node.type : undefined;
+    } else if (isPropertySignature(node)) {
+        const type = node.type;
+        return type ? type.getText() : undefined;
     } else if (node.initializer) {
         const initializer = node.initializer;
         if (initializer !== undefined) {

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -58,31 +58,32 @@ export function isNodeDefaultExported(node: Node): boolean {
  * @returns {(string | undefined)}
  */
 export function getNodeType(node:any): string | undefined {
+    let output = undefined;
     if (node === undefined) {
-        return node;
+        output = node;
     } else if (node instanceof FunctionDeclaration
         || node instanceof PropertyDeclaration
         || node instanceof GetterDeclaration
         || node instanceof SetterDeclaration
         || node instanceof MethodDeclaration
         || node instanceof ParameterDeclaration) {
-        return node.type ? node.type : undefined;
+        output = node.type ? node.type : undefined;
     } else if (isPropertySignature(node)) {
         const type = node.type;
-        return type ? type.getText() : undefined;
+        output = type ? type.getText() : undefined;
     } else if (node.initializer) {
         const initializer = node.initializer;
         if (initializer !== undefined) {
             if (['true', 'false'].indexOf(initializer.getText()) !== -1) {
-                return 'boolean';
+                output = 'boolean';
             }
-            return getNodeType(initializer);
+            output = getNodeType(initializer);
         }
-    } else if (isStringLiteral(node)) {
-        return 'string';
-    } else if (isNumericLiteral(node)) {
-        return 'number';
-    } else if (isArrayLiteralExpression(node)) {
+    } else if (isStringLiteral(node) && output === undefined) {
+        output =  'string';
+    } else if (isNumericLiteral(node) && output === undefined) {
+        output =  'number';
+    } else if (isArrayLiteralExpression(node) && output === undefined) {
         const type:string[]  = [];
         for (let i = 0; node.elements.length > i; i++) {
             const curType:string | undefined = getNodeType(node.elements[i]);
@@ -93,23 +94,25 @@ export function getNodeType(node:any): string | undefined {
             }
         }
         if (type.length === 1) {
-            return 'Array<' + type[0] + '>';
+            output =  'Array<' + type[0] + '>';
+        } else {
+            output = 'Array<any>'; 'Array<any>';
         }
-        return 'Array<any>';
     } else if (isObjectLiteralExpression(node)) {
         let count = 0;
-        let output = '{ ';
+        let out = '{ ';
         for (const prop of node.properties) {
             const identif = prop.getText();
-            output += identif.slice(0, identif.indexOf(':') + 1) + ' ' + getNodeType(prop);
+            out += identif.slice(0, identif.indexOf(':') + 1) + ' ' + getNodeType(prop);
             if (count !== node.properties.length - 1) {
-                output += ', ';
+                out += ', ';
             }
             count += 1;
         }
-        output += ' }';
-        return output;
+        out += ' }';
+        output = out;
     }
+    return output;
 }
 
 /**

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -1,4 +1,4 @@
-import { Declaration, getCombinedModifierFlags, ModifierFlags, Node, SyntaxKind, TypeNode } from 'typescript';
+import { Declaration, getCombinedModifierFlags, ModifierFlags, Node, SyntaxKind, isStringLiteral, isNumericLiteral, isArrayLiteralExpression, isObjectLiteralExpression } from 'typescript';
 
 import { DeclarationVisibility } from '../declarations/DeclarationVisibility';
 import { File } from '../resources/File';
@@ -34,11 +34,53 @@ export function isNodeDefaultExported(node: Node): boolean {
  * Returns the type text (type information) for a given node.
  *
  * @export
- * @param {(TypeNode | undefined)} node
+ * @param {(any)} node
  * @returns {(string | undefined)}
  */
-export function getNodeType(node: TypeNode | undefined): string | undefined {
-    return node ? node.getText() : undefined;
+export function getNodeType(node:any): string | undefined {
+    if( node == undefined ){
+        return node;
+    }
+    else if(node.type){
+        return node.type.getText();
+    }
+    else if(node.initializer){
+        let initializer = node.initializer;
+        if(initializer != undefined){
+            if(["true","false"].indexOf(initializer.getText()) != -1){
+                return "boolean"
+            }
+            return getNodeType(initializer);
+        }
+        
+    }
+    else if(isStringLiteral(node)){
+        return "string"
+    }
+    else if(isNumericLiteral(node)){
+        return "number";
+    }
+    else if(isArrayLiteralExpression(node)){
+        var type:Array<string> = [];
+        for(var i = 0;node.elements.length>i;i++){
+           var curType:string | undefined = getNodeType(node.elements[i]);
+           if(type.length == 0 && curType != undefined ){
+                type.push(curType);
+           }
+           else if(curType != undefined && type.indexOf(curType) == -1){
+               type.push(curType);
+           }
+        }
+        if(type.length ==1){
+            return 'Array<'+type[0]+'>'
+        }
+        else {
+            return 'Array<any>'
+        }
+    }
+    else if(isObjectLiteralExpression(node)){
+        console.log("was object");
+    }
 }
 
 /**

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -1,10 +1,10 @@
-import { 
+import {
     Declaration,
     getCombinedModifierFlags,
     isArrayLiteralExpression,
     isNumericLiteral,
     isObjectLiteralExpression,
-    isStringLiteral, 
+    isStringLiteral,
     ModifierFlags,
     Node,
     SyntaxKind,
@@ -48,56 +48,48 @@ export function isNodeDefaultExported(node: Node): boolean {
  * @returns {(string | undefined)}
  */
 export function getNodeType(node:any): string | undefined {
-    if( node == undefined ) {
+    if (node === undefined) {
         return node;
-    }
-    else if(node.type) {
+    } else if (node.type) {
         return node.type.getText();
-    }
-    else if(node.initializer){
+    } else if (node.initializer) {
         const initializer = node.initializer;
-        if(initializer !== undefined) {
-            if(['true','false'].indexOf(initializer.getText()) !== -1){
+        if (initializer !== undefined) {
+            if (['true', 'false'].indexOf(initializer.getText()) !== -1) {
                 return 'boolean';
             }
             return getNodeType(initializer);
         }
-        
-    }
-    else if(isStringLiteral(node)) {
+    } else if (isStringLiteral(node)) {
         return 'string';
-    }
-    else if(isNumericLiteral(node)) {
+    } else if (isNumericLiteral(node)) {
         return 'number';
-    }
-    else if(isArrayLiteralExpression(node)) {
-        const type:Array<string> = [];
-        for(let i = 0;node.elements.length>i;i++) {
-           let curType:string | undefined = getNodeType(node.elements[i]);
-           if(type.length == 0 && curType !== undefined ) {
+    } else if (isArrayLiteralExpression(node)) {
+        const type:string[]  = [];
+        for (let i = 0; node.elements.length > i; i++) {
+            const curType:string | undefined = getNodeType(node.elements[i]);
+            if (type.length === 0 && curType !== undefined) {
                 type.push(curType);
-           }
-           else if(curType !== undefined && type.indexOf(curType) === -1) {
-               type.push(curType);
-           }
+            } else if (curType !== undefined && type.indexOf(curType) === -1) {
+                type.push(curType);
+            }
         }
-        if(type.length ===1) {
+        if (type.length === 1) {
             return 'Array<' + type[0] + '>';
         }
         return 'Array<any>';
-    }
-    else if(isObjectLiteralExpression(node)) {
+    } else if (isObjectLiteralExpression(node)) {
         let count = 0;
         let output = '{ ';
-        for(const prop of node.properties) {
+        for (const prop of node.properties) {
             const identif = prop.getText();
-            output+= identif.slice(0,identif.indexOf(':') + 1) + ' '+ getNodeType(prop);
-            if(count !== node.properties.length-1) {
-                output+= ', ';
+            output += identif.slice(0, identif.indexOf(':') + 1) + ' ' + getNodeType(prop);
+            if (count !== node.properties.length - 1) {
+                output += ', ';
             }
-            count+=1;
+            count += 1;
         }
-        output+= ' }';
+        output += ' }';
         return output;
     }
 }

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -8,16 +8,8 @@ import {
     ModifierFlags,
     Node,
     SyntaxKind,
+    TypeNode,
 } from 'typescript';
-
-import {
-    FunctionDeclaration,
-    GetterDeclaration,
-    MethodDeclaration,
-    ParameterDeclaration,
-    PropertyDeclaration,
-    SetterDeclaration,
-} from '../declarations';
 
 import { DeclarationVisibility } from '../declarations/DeclarationVisibility';
 import { File } from '../resources/File';
@@ -57,18 +49,13 @@ export function isNodeDefaultExported(node: Node): boolean {
  * @param {(any)} node
  * @returns {(string | undefined)}
  */
-export function getNodeType(node:any): string | undefined {
+export function getNodeType(type: TypeNode | undefined, node:any): string | undefined {
     let output = undefined;
     if (node === undefined) {
         output = node;
-    } else if (node instanceof FunctionDeclaration
-        || node instanceof PropertyDeclaration
-        || node instanceof GetterDeclaration
-        || node instanceof SetterDeclaration
-        || node instanceof MethodDeclaration
-        || node instanceof ParameterDeclaration) {
-        output = node.type ? node.type : undefined;
-    } else if (isPropertySignature(node)) {
+    }
+    output = type ? type.getText() : undefined;
+    if (isPropertySignature(node)) {
         const type = node.type;
         output = type ? type.getText() : undefined;
     } else if (node.initializer) {
@@ -77,7 +64,7 @@ export function getNodeType(node:any): string | undefined {
             if (['true', 'false'].indexOf(initializer.getText()) !== -1) {
                 output = 'boolean';
             }
-            output = getNodeType(initializer);
+            output = getNodeType(undefined, initializer);
         }
     } else if (isStringLiteral(node) && output === undefined) {
         output =  'string';
@@ -86,7 +73,7 @@ export function getNodeType(node:any): string | undefined {
     } else if (isArrayLiteralExpression(node) && output === undefined) {
         const type:string[]  = [];
         for (let i = 0; node.elements.length > i; i++) {
-            const curType:string | undefined = getNodeType(node.elements[i]);
+            const curType:string | undefined = getNodeType(undefined, node.elements[i]);
             if (type.length === 0 && curType !== undefined) {
                 type.push(curType);
             } else if (curType !== undefined && type.indexOf(curType) === -1) {
@@ -103,7 +90,7 @@ export function getNodeType(node:any): string | undefined {
         let out = '{ ';
         for (const prop of node.properties) {
             const identif = prop.getText();
-            out += identif.slice(0, identif.indexOf(':') + 1) + ' ' + getNodeType(prop);
+            out += identif.slice(0, identif.indexOf(':') + 1) + ' ' + getNodeType(undefined, prop);
             if (count !== node.properties.length - 1) {
                 out += ', ';
             }

--- a/src/node-parser/parse-utilities.ts
+++ b/src/node-parser/parse-utilities.ts
@@ -79,7 +79,18 @@ export function getNodeType(node:any): string | undefined {
         }
     }
     else if(isObjectLiteralExpression(node)){
-        console.log("was object");
+        var count = 0;
+        let output = "{ ";
+        for(let prop of node.properties){
+            let identif = prop.getText();
+            output+= identif.slice(0,identif.indexOf(":")+1)+" "+getNodeType(prop);
+            if(count != node.properties.length-1){
+                output+=", "
+            }
+            count+=1;
+        }
+        output+=" }"
+        return output;
     }
 }
 

--- a/src/node-parser/variable-parser.ts
+++ b/src/node-parser/variable-parser.ts
@@ -21,7 +21,7 @@ export function parseVariable(parent: Resource | CallableDeclaration, node: Vari
                 o.name.getText(),
                 isConst,
                 isNodeExported(node),
-                getNodeType(o.type),
+                getNodeType(o),
                 node.getStart(),
                 node.getEnd(),
             );

--- a/src/node-parser/variable-parser.ts
+++ b/src/node-parser/variable-parser.ts
@@ -21,7 +21,7 @@ export function parseVariable(parent: Resource | CallableDeclaration, node: Vari
                 o.name.getText(),
                 isConst,
                 isNodeExported(node),
-                getNodeType(o),
+                getNodeType(o.type, o),
                 node.getStart(),
                 node.getEnd(),
             );


### PR DESCRIPTION
- Used initializers to get types when they are not defined in node.type(mostly in js).

This solves this [issue](https://github.com/buehler/node-typescript-parser/issues/97)