### PR TITLE
Add support for extends and implements

### DIFF
--- a/src/declarations/ClassDeclaration.ts
+++ b/src/declarations/ClassDeclaration.ts
@@ -1,6 +1,8 @@
 import { AccessorDeclaration } from './AccessorDeclaration';
 import { ConstructorDeclaration } from './ConstructorDeclaration';
-import { ClassLikeDeclaration, ExportableDeclaration, GenericDeclaration } from './Declaration';
+import { AbstractDeclaration, ClassLikeDeclaration, ExportableDeclaration, GenericDeclaration,
+} from './Declaration';
+import { InterfaceDeclaration } from './InterfaceDeclaration';
 import { MethodDeclaration } from './MethodDeclaration';
 import { PropertyDeclaration } from './PropertyDeclaration';
 
@@ -12,18 +14,27 @@ import { PropertyDeclaration } from './PropertyDeclaration';
  * @implements {ClassLikeDeclaration}
  * @implements {ExportableDeclaration}
  * @implements {GenericDeclaration}
+ * @implements {AbstractDeclaration}
  */
-export class ClassDeclaration implements ClassLikeDeclaration, ExportableDeclaration, GenericDeclaration {
+export class ClassDeclaration
+    implements
+        ClassLikeDeclaration,
+        ExportableDeclaration,
+        GenericDeclaration,
+        AbstractDeclaration
+{
     public ctor: ConstructorDeclaration | undefined;
     public accessors: AccessorDeclaration[] = [];
     public properties: PropertyDeclaration[] = [];
     public methods: MethodDeclaration[] = [];
     public typeParameters: string[] | undefined;
-
+    public isAbstract: boolean = false;
+    public implements: InterfaceDeclaration[] = [];
+    public extends: ClassDeclaration[] = [];
     constructor(
         public name: string,
         public isExported: boolean,
         public start?: number,
         public end?: number,
-    ) { }
+  ) {}
 }

--- a/src/declarations/Declaration.ts
+++ b/src/declarations/Declaration.ts
@@ -1,6 +1,8 @@
 import { Node } from '../Node';
 import { AccessorDeclaration } from './AccessorDeclaration';
+import { ClassDeclaration } from './ClassDeclaration';
 import { DeclarationVisibility } from './DeclarationVisibility';
+import { InterfaceDeclaration } from './InterfaceDeclaration';
 import { MethodDeclaration } from './MethodDeclaration';
 import { ParameterDeclaration } from './ParameterDeclaration';
 import { PropertyDeclaration } from './PropertyDeclaration';
@@ -131,6 +133,22 @@ export interface ClassLikeDeclaration extends Declaration {
      * @memberof ClassLikeDeclaration
      */
     methods: MethodDeclaration[];
+
+    /**
+     * The methods of the declaration.
+     *
+     * @type {InterfaceDeclaration[]}
+     * @memberof ClassLikeDeclaration
+     */
+    implements: InterfaceDeclaration[];
+
+    /**
+     * The methods of the declaration.
+     *
+     * @type {ClassDeclaration[]}
+     * @memberof ClassLikeDeclaration
+     */
+    extends: ClassDeclaration[];
 }
 
 /**

--- a/src/declarations/InterfaceDeclaration.ts
+++ b/src/declarations/InterfaceDeclaration.ts
@@ -1,4 +1,5 @@
 import { AccessorDeclaration } from './AccessorDeclaration';
+import { ClassDeclaration } from './ClassDeclaration';
 import { ClassLikeDeclaration, ExportableDeclaration, GenericDeclaration } from './Declaration';
 import { MethodDeclaration } from './MethodDeclaration';
 import { PropertyDeclaration } from './PropertyDeclaration';
@@ -16,6 +17,8 @@ export class InterfaceDeclaration implements ClassLikeDeclaration, ExportableDec
     public typeParameters: string[] | undefined;
     public properties: PropertyDeclaration[] = [];
     public methods: MethodDeclaration[] = [];
+    implements: InterfaceDeclaration[] = [];
+    extends: ClassDeclaration[] = [];
 
     constructor(
         public name: string,

--- a/src/node-parser/class-parser.ts
+++ b/src/node-parser/class-parser.ts
@@ -6,10 +6,12 @@ import {
     Node,
     ObjectBindingPattern,
     SyntaxKind,
+    isHeritageClause,
 } from 'typescript';
 
 import { GetterDeclaration, SetterDeclaration } from '../declarations/AccessorDeclaration';
 import { ClassDeclaration as TshClass } from '../declarations/ClassDeclaration';
+import { InterfaceDeclaration as TshInterface } from '../declarations/InterfaceDeclaration';
 import { ConstructorDeclaration as TshConstructor } from '../declarations/ConstructorDeclaration';
 import { DefaultDeclaration as TshDefault } from '../declarations/DefaultDeclaration';
 import { MethodDeclaration as TshMethod } from '../declarations/MethodDeclaration';
@@ -130,6 +132,9 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
         classDeclaration.typeParameters = node.typeParameters.map(param => param.getText());
     }
 
+    classDeclaration.isAbstract = node.modifiers !== undefined
+        && node.modifiers.some(m => m.kind === SyntaxKind.AbstractKeyword);
+
     if (node.members) {
         node.members.forEach((o) => {
             if (isPropertyDeclaration(o)) {
@@ -213,6 +218,33 @@ export function parseClass(tsResource: Resource, node: ClassDeclaration): void {
                 parseFunctionParts(tsResource, method, o);
             }
         });
+    }
+    
+    if (node.heritageClauses) {
+        node.heritageClauses.forEach((o) => {
+            if(isHeritageClause(o)){
+                o.types.forEach((type) => {
+                    if(o.token == SyntaxKind.ExtendsKeyword){
+                        const className = (type.expression as Identifier).escapedText;
+                        classDeclaration.extends.push(
+                            new TshClass(
+                                className.toString(),
+                                classDeclaration.isExported
+                            )
+                        );
+                    }else if(o.token == SyntaxKind.ImplementsKeyword){
+                        const interfaceName = (type.expression as Identifier).escapedText;
+                        classDeclaration.implements.push(
+                            new TshInterface(
+                                interfaceName.toString(),
+                                classDeclaration.isExported
+                            )
+                        );
+                    }
+                });
+            }
+        })
+        
     }
 
     parseClassIdentifiers(tsResource, node);

--- a/src/type-guards/TypescriptGuards.ts
+++ b/src/type-guards/TypescriptGuards.ts
@@ -5,6 +5,7 @@ import {
     ExternalModuleReference,
     FunctionDeclaration,
     GetAccessorDeclaration,
+    HeritageClause,
     Identifier,
     ImportDeclaration,
     ImportEqualsDeclaration,
@@ -229,4 +230,15 @@ export function isGetAccessorDeclaration(node?: Node): node is GetAccessorDeclar
  */
 export function isSetAccessorDeclaration(node?: Node): node is SetAccessorDeclaration {
     return node !== undefined && node.kind === SyntaxKind.SetAccessor;
+}
+
+/**
+ * Determines if the given node is a HeritageClause.
+ *
+ * @export
+ * @param {Node} [node]
+ * @returns {node is SetAccessorDeclaration}
+ */
+export function isHeritageClause(node?: Node): node is HeritageClause {
+    return node !== undefined && node.kind === SyntaxKind.HeritageClause;
 }


### PR DESCRIPTION
Rough implementation of feature requested in issue #88.

This creates a new class/interface declaration with only the name of the inherited/implemented entity. 

An improvement that could be done would be searching for the definition in the AST and referencing the already created object. Any input on how this could be achieved would be appreciated.